### PR TITLE
Helm : fix selector for relay svc

### DIFF
--- a/helm/hubble-gke-exporter/templates/svc-relay.yaml
+++ b/helm/hubble-gke-exporter/templates/svc-relay.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: {{ .Values.service.relay.type }}
   selector:
-    app.kubernetes.io/name: gke-hubble-export
+    app.kubernetes.io/name: hubble-relay
   ports:
     - protocol: TCP
       port: {{ .Values.service.relay.port }}


### PR DESCRIPTION
When deploying with helm chart, the hubble backend was unable to connect to the relay service because it was pointing at exporter pods (daemonset) with a port that is not open (port 4245), so triggering the following error :  

```
level=error msg="fetching hubble flows: connecting to hubble-relay (attempt #3) failed: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.171.46.113:80: connect: connection refused\"\n" subsys=ui-backend
```

This PR fixes the selector of the service to point at relay pod. 