### PR TITLE
feat: add custom pod labels and annotations

### DIFF
--- a/helm/hubble-gke-exporter/templates/daemonset-exporter.yaml
+++ b/helm/hubble-gke-exporter/templates/daemonset-exporter.yaml
@@ -17,8 +17,15 @@ spec:
       maxUnavailable: 10
   template:
     metadata:
+      annotations:
+        {{- with .Values.exporter.spec.podAnnotations }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}      
       labels:
         app.kubernetes.io/name: gke-hubble-export
+        {{- with .Values.exporter.spec.podLabels }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
         {{- include "hubble-gke-exporter.labels" . | nindent 8 }}
     spec:
       hostNetwork: {{ .Values.exporter.spec.hostNetwork }}

--- a/helm/hubble-gke-exporter/templates/deployment-relay.yaml
+++ b/helm/hubble-gke-exporter/templates/deployment-relay.yaml
@@ -14,8 +14,15 @@ spec:
       {{- include "hubble-gke-exporter.labels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- with .Values.relay.spec.podAnnotations }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}   
       labels:
         app.kubernetes.io/name: hubble-relay
+        {{- with .Values.relay.spec.podLabels }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
         {{- include "hubble-gke-exporter.labels" . | nindent 8 }}
     spec:
       containers:

--- a/helm/hubble-gke-exporter/templates/deployment-ui.yaml
+++ b/helm/hubble-gke-exporter/templates/deployment-ui.yaml
@@ -14,8 +14,15 @@ spec:
       {{- include "hubble-gke-exporter.labels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- with .Values.ui.spec.podAnnotations }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}   
       labels:
         app.kubernetes.io/name: hubble-ui
+        {{- with .Values.ui.spec.podLabels }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
         {{- include "hubble-gke-exporter.labels" . | nindent 8 }}
     spec:
       serviceAccount: {{ include "hubble-gke-exporter.fullname" . }}-ui

--- a/helm/hubble-gke-exporter/values.yaml
+++ b/helm/hubble-gke-exporter/values.yaml
@@ -13,6 +13,8 @@ exporter:
       - operator: Exists
       - key: components.gke.io/gke-managed-components
         operator: Exists
+    podLabels: {}
+    podAnnotations: {}
 
 ui:
   frontend:
@@ -32,6 +34,8 @@ ui:
       imagePullPolicy: IfNotPresent
   spec:    
     replicas: 1
+    podLabels: {}
+    podAnnotations: {}
 
 relay:
   image:
@@ -39,6 +43,8 @@ relay:
     imagePullPolicy: IfNotPresent
   spec:    
     replicas: 1
+    podLabels: {}
+    podAnnotations: {}
 
 service:
   relay:


### PR DESCRIPTION
A small PR that adds the option to set custom pod level annotations and labels. This is helpful for some management applications or policies :) 