### PR TITLE
feat: add pod level security context

### DIFF
--- a/helm/hubble-gke-exporter/templates/daemonset-exporter.yaml
+++ b/helm/hubble-gke-exporter/templates/daemonset-exporter.yaml
@@ -33,6 +33,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.exporter.spec.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: gke-hubble-export
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"

--- a/helm/hubble-gke-exporter/templates/deployment-relay.yaml
+++ b/helm/hubble-gke-exporter/templates/deployment-relay.yaml
@@ -25,6 +25,10 @@ spec:
         {{- end }}
         {{- include "hubble-gke-exporter.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.exporter.spec.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: hubble-relay
           image: "{{ .Values.relay.image.repository }}:v{{ .Chart.AppVersion }}"

--- a/helm/hubble-gke-exporter/templates/deployment-ui.yaml
+++ b/helm/hubble-gke-exporter/templates/deployment-ui.yaml
@@ -25,6 +25,10 @@ spec:
         {{- end }}
         {{- include "hubble-gke-exporter.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.exporter.spec.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccount: {{ include "hubble-gke-exporter.fullname" . }}-ui
       serviceAccountName: {{ include "hubble-gke-exporter.fullname" . }}-ui
       containers:

--- a/helm/hubble-gke-exporter/values.yaml
+++ b/helm/hubble-gke-exporter/values.yaml
@@ -15,6 +15,7 @@ exporter:
         operator: Exists
     podLabels: {}
     podAnnotations: {}
+    podSecurityContext: {}
     securityContext: {}
 
 ui:
@@ -43,6 +44,7 @@ ui:
     replicas: 1
     podLabels: {}
     podAnnotations: {}
+    podSecurityContext: {}
 
 relay:
   image:
@@ -52,6 +54,7 @@ relay:
     replicas: 1
     podLabels: {}
     podAnnotations: {}
+    podSecurityContext: {}
     securityContext: {}
 
 service:


### PR DESCRIPTION
Expose `PodSecurityContext v1 core` fields for all deployments and daemonset.